### PR TITLE
Remove input thread blocking. API Response in pretty json format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 RioDB (www.riodb.org) is a downloadable software for data stream processing.  
 You can build powerful data screening bots through simple SQL-like statements.
 
-## In a nuthshell:
+## In a nutshell:
 
 - You define streams that will receive data using plugins (udp, tcp, http, etc.)
 - You define windows of data (example: messages received in the last 2 hours that contain the word 'free'.)

--- a/pom.xml
+++ b/pom.xml
@@ -84,12 +84,17 @@
 		<dependency>
 			<groupId>org.riodb</groupId>
 			<artifactId>RioDBPlugin</artifactId>
-			<version>0.0.3</version>
+			<version>0.0.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>31.0.1-jre</version>
+		</dependency>
+		<dependency>
+   			<groupId>com.google.code.gson</groupId>
+    		<artifactId>gson</artifactId>
+    		<version>2.9.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/org/riodb/engine/Stream.java
+++ b/src/org/riodb/engine/Stream.java
@@ -338,7 +338,7 @@ public class Stream implements Runnable {
 				// get next message from dataSource. non-blocking. Null can be returned.
 				RioDBStreamMessage message = streamInput.getNextInputMessage();
 				if (message != null) {
-
+					
 					/*
 					 * Tell windowManager to run this message on ALL windows. Collect all windows
 					 * responses (windowSummary) into array. This array is filled with the clone of
@@ -356,7 +356,9 @@ public class Stream implements Runnable {
 					// Send message + window summaries to Queries for processing.
 					sendMessageResultsRefToQueries(ews);
 
-				} else {
+				} 
+				/*
+				else {
 					/*
 					 * UPDATE: This sleep block should be removed. It should be a responsibility of the 
 					 * plugin to implement a blocking queue or busy-waiting on the plugin side. Then
@@ -364,13 +366,14 @@ public class Stream implements Runnable {
 					 * based on the plugin's purpose.  
 					 * Once this is removed, RioDB will not have any performance safety net!
 					 * it will be up to the plugin.
-					 */
+					 * /
 					try {
 						Thread.sleep(1);
 					} catch (InterruptedException e) {
 						;
 					}
 				}
+				*/
 			}
 
 		} catch (RioDBPluginException e) {

--- a/src/org/riodb/engine/SystemSettings.java
+++ b/src/org/riodb/engine/SystemSettings.java
@@ -426,7 +426,7 @@ public class SystemSettings {
 		for (String file : sqlFiles) {
 
 			// Print the names of files and directories
-			if (true) {// file.toLowerCase().endsWith(("." + RQL_FILE_EXTENSION))) {
+			if (file.toLowerCase().endsWith(("." + RQL_FILE_EXTENSION))) {
 
 				String fileName = adaptPathSlashes(sqlDirectory + file);
 

--- a/src/org/riodb/sql/SQLParser.java
+++ b/src/org/riodb/sql/SQLParser.java
@@ -649,7 +649,6 @@ public final class SQLParser {
 		return word;
 	}
 
-	
 	// Function to encode any quoted text into base64
 	static final String encodeQuotedText(String s) {
 
@@ -741,6 +740,51 @@ public final class SQLParser {
 
 	}
 
+	// function to decode base64 text in quotes only. Substituting single quotes for double quotes. 
+	public static final String decodeQuotedTextToDoubleQuoted(String s) {
+
+		// System.out.println("decoding:"+s);
+
+		if (s == null) {
+			return null;
+		}
+
+		boolean inQuote = false;
+		ArrayList<Integer> quoteBeginList = new ArrayList<Integer>();
+		ArrayList<Integer> quoteEndList = new ArrayList<Integer>();
+		for (int i = 0; i < s.length(); i++) {
+			if (s.charAt(i) == '\'') {
+				if (inQuote) {
+					inQuote = false;
+					quoteEndList.add(i);
+				} else {
+					inQuote = true;
+					quoteBeginList.add(i);
+				}
+			}
+		}
+
+		String r = s;
+		for (int i = 0; i < quoteEndList.size(); i++) {
+
+			if (i < quoteEndList.size()) {
+				String t = s.substring(quoteBeginList.get(i) + 1, quoteEndList.get(i));
+				byte[] decodedBytes = Base64.getDecoder().decode(t.replace("$", "="));
+				String d = new String(decodedBytes);
+				d.replace("''","'");
+				t = "'" + t + "'";
+				d = "\"" + d + "\"";
+				// System.out.println("replacing... "+ t + " -> " + d);
+				r = r.replace(t, d);
+			}
+		}
+
+		// System.out.println("Decoded: "+ r);
+
+		return r;
+
+	}
+
 	// function to decode base64
 	public static final String decodeText(String s) {
 
@@ -748,8 +792,8 @@ public final class SQLParser {
 			byte[] decodedBytes = Base64.getDecoder().decode(s.replace("$", "="));
 			return new String(decodedBytes);
 		} catch (IllegalArgumentException iae) {
-			//System.out.println("SQLParser attempted to decode invalid base64 string: "+ s);
-			return null;
+			// if s is invalid Base64, return original s
+			return s;
 		}
 	}
 

--- a/src/org/riodb/sql/SQLQueryColumnOperations.java
+++ b/src/org/riodb/sql/SQLQueryColumnOperations.java
@@ -40,7 +40,7 @@ final public class SQLQueryColumnOperations {
 
 				String itemStrParts[] = selectItemStr[i].split(" ");
 				boolean undefined = false;
-
+				
 				if (itemStrParts.length == 0 || (itemStrParts.length == 1 && itemStrParts[0].length() == 0)) {
 					undefined = true;
 				} else if (itemStrParts.length == 1) {
@@ -329,6 +329,10 @@ final public class SQLQueryColumnOperations {
 				int functionId = SQLFunctionMap.getFunctionId(words[i]);
 				words[i] = "windowSummaries[0]."+ SQLFunctionMap.getFunctionCall(functionId);
 			}
+			else if(SQLParser.isMathFunction(words[i])) {
+				words[i] = "Math." + words[i];
+			}
+			
 			else if(SQLParser.isStreamField(streamId, words[i]) ) {
 				int fieldId = RioDB.rio.getEngine().getStream(streamId).getDef().getFieldId(words[i]);
 				boolean isNumeric = RioDB.rio.getEngine().getStream(streamId).getDef().isNumeric(fieldId);

--- a/src/org/riodb/sql/SQLQueryConditionString.java
+++ b/src/org/riodb/sql/SQLQueryConditionString.java
@@ -21,7 +21,7 @@
 
 /*
  * Windows don't have string values, only numeric. 
- * So for the HAVING condition on a string field, it must pertain to a field from the message. 
+ * So for the WHEN condition on a string field, it must pertain to a field from the message. 
  * we just wrap this and pass to the SQLWhereConditionString (for message string conditions)
  * 
  */

--- a/src/org/riodb/windows/WindowOfOne.java
+++ b/src/org/riodb/windows/WindowOfOne.java
@@ -51,7 +51,7 @@ public class WindowOfOne implements Window {
 		this.requiresPrevious = requiresPrevious;
 		this.partitionExpiration = partitionExpiration;
 		
-		RioDB.rio.getSystemSettings().getLogger().debug("constructing Window of one slot");
+		RioDB.rio.getSystemSettings().getLogger().debug("\tconstructing Window of one slot");
 		
 	}
 	

--- a/src/org/riodb/windows/WindowOfQuantity.java
+++ b/src/org/riodb/windows/WindowOfQuantity.java
@@ -158,7 +158,7 @@ public class WindowOfQuantity implements Window {
 		this.requiresSum = functionsRequired[SQLFunctionMap.getFunctionId("sum")];
 		this.requiresVariance = functionsRequired[SQLFunctionMap.getFunctionId("variance")];
 
-		RioDB.rio.getSystemSettings().getLogger().debug("constructing Window of Quantity");
+		RioDB.rio.getSystemSettings().getLogger().debug("\tconstructing Window of Quantity");
 
 		// start empty initial stack
 		initialQueue = new ArrayDeque<Double>();

--- a/src/org/riodb/windows/WindowOfTimeComplex.java
+++ b/src/org/riodb/windows/WindowOfTimeComplex.java
@@ -153,7 +153,7 @@ public class WindowOfTimeComplex implements Window {
 		this.requiresSum = functionsRequired[SQLFunctionMap.getFunctionId("sum")];
 		this.requiresVariance = functionsRequired[SQLFunctionMap.getFunctionId("variance")];
 
-		RioDB.rio.getSystemSettings().getLogger().debug("constructing Window of time, complex");
+		RioDB.rio.getSystemSettings().getLogger().debug("\tconstructing Window of time, complex");
 
 		windowSummary = new WindowSummary();
 


### PR DESCRIPTION
Remove input thread blocking. Moves this responsibility to the input plugin. RioDB engine will just call input plugin for new data in a loop without any blocking mechanism. This gives the plugin freedom to implement their own blocking mechanism (or busy waiting).   
  
Adds API Response in pretty json format when request contains ?pretty=true
  
fixes sliding window eviction bug.  

fixes some SQL parsing bugs. 