### PR TITLE
remove ExecutorService for output thread pool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![N|Solid](https://www.riodb.org/images/Logo_Name_Small.jpg)](https://www.riodb.org/index.html)
+[![N|Solid](https://www.riodb.org/images/logo_s.jpg)](https://www.riodb.org/index.html)
 
 RioDB (www.riodb.org) is a downloadable software for data stream processing.  
 You can build powerful data screening bots through simple SQL-like statements.

--- a/src/org/riodb/engine/Engine.java
+++ b/src/org/riodb/engine/Engine.java
@@ -29,16 +29,12 @@
 
 package org.riodb.engine;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.riodb.sql.ExceptionSQLStatement;
 import org.riodb.plugin.RioDBPluginException;
 
 public class Engine {
 	
-	private static final int DEFAULT_OUTPUT_WORKERS = 2;
-
 	/*
 	 * Stream array: For performance reasons, we're not using ArrayList. Just a
 	 * simple array of objects. This means that adding/removing require rebuilding
@@ -76,19 +72,6 @@ public class Engine {
 	// getter to increment and get the next counter value
 	public int counterNext() {
 		return globalCounter.incrementAndGet();
-	}
-
-	// Worker threads for sending OUTPUT operations
-	private static ExecutorService outputWorkers = Executors.newFixedThreadPool(DEFAULT_OUTPUT_WORKERS);
-
-	// outputWorkers getter
-	public ExecutorService getOutputWorkers() {
-		return outputWorkers;
-	}
-
-	// outputWorkers setter
-	public void setOutputWorkers(int output_worker_threads) {
-		outputWorkers = Executors.newFixedThreadPool(output_worker_threads);
 	}
 
 	// Method for adding a new Stream

--- a/src/org/riodb/engine/RioDB.java
+++ b/src/org/riodb/engine/RioDB.java
@@ -42,13 +42,14 @@ import org.riodb.plugin.RioDBPluginException;
 
 public class RioDB {
 	
+	// software version
 	public static final String VERSION = "0.0.1";
 	
+	// A class that contains system settings
 	private final static SystemSettings settings = new SystemSettings();
 	public SystemSettings getSystemSettings() {
 		return settings;
 	}
-	
 	
 	// Engine that contains and runs streams, windows, queries, etc.
 	private final Engine rioEngine = new Engine();
@@ -61,6 +62,7 @@ public class RioDB {
 	public void setUserMgr(String credentialsFile) throws ExceptionAccessMgt {
 		userMgr = new UserManager(credentialsFile);
 	}
+	// getter for userMgr
 	public UserManager getUserMgr(){
 		return userMgr;
 	}
@@ -69,15 +71,13 @@ public class RioDB {
 	public static final RioDB rio = new RioDB();
 
 	
-	
-	// shutdown
+	// shutdown procedure
 	private void shutdown() {
 		rio.getEngine().stop();
 		Clock.sleep(10);
 		HTTPInterface.stop();
 	}
 
-	
 	
 	/// MAIN
 	public static void main(String[] args) throws InterruptedException {

--- a/src/org/riodb/engine/Stream.java
+++ b/src/org/riodb/engine/Stream.java
@@ -140,9 +140,8 @@ public class Stream implements Runnable {
 				+ "\"," + "\n   \"window_count\": " + streamWindowMgr.getWindowCount() + ","
 				+ "\n   \"handler_thread\": \"" + threadStatus + "\","
 				// + "\n \"message_queue_size\": " + streamPacketInbox.size() + ","
-				+ "\n   \"query_thread\": \"" + streamQueryMgr.status() + "\"," + "\n   \"query_count\": "
-				+ streamQueryMgr.queryCount() + "," + "\n   \"query_queue_size\": " + streamQueryMgr.inboxSize()
-				+ "\n }";
+				+ "\n   \"query_count\": "	+ streamQueryMgr.queryCount() 
+				+ "\n}";
 		return s;
 	}
 
@@ -223,7 +222,7 @@ public class Stream implements Runnable {
 				
 				Clock.sleep(40);
 				
-				RioDB.rio.getSystemSettings().getLogger().debug("Stream.start: started.");
+				RioDB.rio.getSystemSettings().getLogger().debug("Stream.start(): started.");
 			} catch (RioDBPluginException e) {
 				interrupt = true;
 				String s = "Error starting input plugin: " + e.getMessage().replace("\n", "").replace("\r", "");
@@ -240,7 +239,7 @@ public class Stream implements Runnable {
 	// Stop this steram and all its dependencies
 	public void stop() {
 
-		RioDB.rio.getSystemSettings().getLogger().debug("Stream.stop: stopping " + streamName);
+		RioDB.rio.getSystemSettings().getLogger().debug("Stream.stop(): stopping " + streamName);
 
 		// stop data source first
 		if (interrupt == false) {

--- a/src/org/riodb/engine/SystemSettings.java
+++ b/src/org/riodb/engine/SystemSettings.java
@@ -94,13 +94,12 @@ public class SystemSettings {
 	// persist user statements to disk, and recover them on reboot/startup
 	private static PersistedStatements persistedStatements;
 
-	// default number of Threads allocated for executing output actions:
-	private static int output_worker_threads = 1;
-
+	// get persisted statements
 	public PersistedStatements getPersistedStatements() {
 		return persistedStatements;
 	}
 
+	// get plugin directory
 	public String getPluginDirectory() {
 		return pluginJarDirectory;
 	}
@@ -316,17 +315,6 @@ public class SystemSettings {
 
 		if (confProperties.containsKey("plugin_dir")) {
 			pluginJarDirectory = confProperties.get("plugin_dir");
-		}
-
-		if (confProperties.containsKey("output_workers")) {
-			if (SQLParser.isNumber(confProperties.get("output_workers"))
-					&& Integer.valueOf(confProperties.get("output_workers")) > 0) {
-				output_worker_threads = Integer.valueOf(confProperties.get("output_workers"));
-				RioDB.rio.getEngine().setOutputWorkers(output_worker_threads);
-			} else {
-				logger.fatal("Configuration error: 'output_workers' must be a positive integer.");
-				return false;
-			}
 		}
 
 		// format sqlDirectory path

--- a/src/org/riodb/queries/Query.java
+++ b/src/org/riodb/queries/Query.java
@@ -153,13 +153,8 @@ public class Query {
 				columnValues[i] = columns[i].getValue(esum.getMessageRef(), esum.getWindowSummariesRef());
 			}
 
-			// execute output action using reusable threads provided by an ExecutorService.
-			RioDB.rio.getEngine().getOutputWorkers().execute(new Runnable() {
-			    @Override
-			    public void run() {
-			    	output.sendOutput(columnValues);
-			    }
-			});
+			// send output to output plugin.
+			output.sendOutput(columnValues);
 			
 
 			// set timeout if necessary for this query
@@ -239,11 +234,13 @@ public class Query {
 	
 	// start plugin (in case it has a startup procedure)
 	public void start() throws RioDBPluginException {
+		RioDB.rio.getSystemSettings().getLogger().debug("Query.start(): starting query " + queryId);
 		output.start();
 	}
 	
 	// stop plugin (in case it has stop steps)
 	public void stop() throws RioDBPluginException {
+		RioDB.rio.getSystemSettings().getLogger().debug("Query.stop(): stopping query" + queryId);
 		output.stop();
 	}
 }


### PR DESCRIPTION
From now on, output plugins are responsible for managing their own thread pools.  
This adds flexibility to the plugin. For example, to maintain a JDBC database connection pool.  
It also improves performance dramatically if RioDB is to stream output. 