### PR TITLE
Implemented String scaler functions

### DIFF
--- a/src/org/riodb/sql/SQLScalarFunctions.java
+++ b/src/org/riodb/sql/SQLScalarFunctions.java
@@ -16,7 +16,7 @@ public final class SQLScalarFunctions {
 	private static String[] numericFunctions = { "to_number", "decode_number", "length" };
 
 	// SQLScalarFunctionsReturningString
-	private static String[] stringFunctions = { "decode", "concat", "to_string" };
+	private static String[] stringFunctions = { "decode", "concat", "to_string", "upper", "lower", "replace", "substr" };
 
 	/*
 	 * 

--- a/src/org/riodb/sql/SQLScalarFunctionsReturningString.java
+++ b/src/org/riodb/sql/SQLScalarFunctionsReturningString.java
@@ -1,8 +1,8 @@
 /*
  	Copyright (c) 2021 Lucio D Matos,  www.riodb.org
- 
+
     This file is part of RioDB
-    
+
     RioDB is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -15,17 +15,17 @@
 
     A copy of the GNU General Public License should be found in the root
     directory. If not, see <https://www.gnu.org/licenses/>.
- 
+
 */
 
 /*
  *   Scalar functions that return STRING
- *   
+ *
  *   Instructions to add a new function:
- *   
+ *
  *   1- add the function name (in lower-case) to the array of functions
  *   2- write the function, with its name in lowercase always!
- *   
+ *
  */
 package org.riodb.sql;
 
@@ -90,4 +90,7 @@ public final class SQLScalarFunctionsReturningString {
         return (s == null) ? null : s.toUpperCase();
     }
 
+    public static String lower(String s) {
+        return (s == null) ? null : s.toLowerCase();
+    }
 }

--- a/src/org/riodb/sql/SQLScalarFunctionsReturningString.java
+++ b/src/org/riodb/sql/SQLScalarFunctionsReturningString.java
@@ -86,4 +86,8 @@ public final class SQLScalarFunctionsReturningString {
 		return o.toString();
 	}
 
+    public static String upper(String s) {
+        return (s == null) ? null : s.toUpperCase();
+    }
+
 }

--- a/src/org/riodb/sql/SQLScalarFunctionsReturningString.java
+++ b/src/org/riodb/sql/SQLScalarFunctionsReturningString.java
@@ -93,4 +93,8 @@ public final class SQLScalarFunctionsReturningString {
     public static String lower(String s) {
         return (s == null) ? null : s.toLowerCase();
     }
+
+    public static String substr(String s, int from) throws StringIndexOutOfBoundsException {
+        return (s == null) ? null : s.substring(from);
+    }
 }

--- a/src/org/riodb/sql/SQLScalarFunctionsReturningString.java
+++ b/src/org/riodb/sql/SQLScalarFunctionsReturningString.java
@@ -97,4 +97,8 @@ public final class SQLScalarFunctionsReturningString {
     public static String substr(String s, int from) throws StringIndexOutOfBoundsException {
         return (s == null) ? null : s.substring(from);
     }
+
+    public static String substr(String s, int from, int to) throws StringIndexOutOfBoundsException {
+        return (s == null) ? null : s.substring(from, to);
+    }
 }

--- a/src/org/riodb/sql/SQLScalarFunctionsReturningString.java
+++ b/src/org/riodb/sql/SQLScalarFunctionsReturningString.java
@@ -94,6 +94,10 @@ public final class SQLScalarFunctionsReturningString {
         return (s == null) ? null : s.toLowerCase();
     }
 
+    public static String replace(String s, String old_s, String new_s) {
+        return (s == null) ? null : s.replace(old_s, new_s);
+    }
+
     public static String substr(String s, int from) throws StringIndexOutOfBoundsException {
         return (s == null) ? null : s.substring(from);
     }


### PR DESCRIPTION
Added the following String methods:

- `upper(String s)`
- `lower(String s)`
- `replace(String s, String old_s, String new_s)`
- `substr(String s, int from)`
- `substr(String s, int from, int to)`

the only thing I needed to modify was the declaration of: 
```java
public String replace(String s, String old, String new) {}
```
since the word `new` can't be used as parameter name. This is because the name `new` is a reserved keyword of Java. I renamed `old` to `old_s` and `new` to `new_s`:

```java
public String replace(String s, String old_s, String new_s) {}
```

One last thing to note is that I don't really know how to declare two methods with the same name in the `stringFunctions` array. For now it is declared once:

```java
private static String[] stringFunctions = { "decode", "concat", "to_string", "upper", "lower", "replace", "substr" };
```